### PR TITLE
use template geoRSS

### DIFF
--- a/src/rss/compile-rss-feed.ts
+++ b/src/rss/compile-rss-feed.ts
@@ -52,11 +52,13 @@ function generateRssItem(geojsonFeature: Feature, feedTemplate: RssDatasetTempla
     return interpolatedFields;
   }
 
+  // at this point georss is not present in feed template
+  // so generate georss from geojson
   return geometry && geometry.type == 'Polygon' ? getFieldsWithGeoRss(interpolatedFields, geojsonFeature) : interpolatedFields;
 }
 
 function hasGeoRssTemplateString(interpolatedFields) {
-  return /{{(.*?)}}/.test(_.get(interpolatedFields, 'item.georss:where', ''))
+  return /{{(.*?)}}/.test(_.get(interpolatedFields, 'item.georss:where', ''));
 }
 
 function getFieldsWithGeoRss(rssItem: Record<string, any>, feature: Feature): Record<string, any> {

--- a/src/rss/compile-rss-feed.ts
+++ b/src/rss/compile-rss-feed.ts
@@ -3,6 +3,7 @@ import { XMLBuilder } from 'fast-xml-parser';
 import { defaultXmlOptions } from './index';
 import { ServiceError } from './service-error';
 import * as geojsonExtent from '@mapbox/geojson-extent';
+import * as _ from 'lodash';
 
 export type RssDatasetTemplate = Record<string, any>;
 type Feature = {
@@ -39,9 +40,24 @@ function generateRssItem(geojsonFeature: Feature, feedTemplate: RssDatasetTempla
     feedTemplateTransforms
   );
 
+  // if georss element is present in rss feed template
+  // use georss from template else generate georss from
+  // geojson
+  if (_.get(interpolatedFields, 'item.georss:where')) {
+    // if interpolated georss feed template contains template string 
+    // it means that the georss is not valid. So, remote it from feed.
+    if (hasGeoRssTemplateString(interpolatedFields)) {
+      _.unset(interpolatedFields, 'item.georss:where');
+    }
+    return interpolatedFields;
+  }
+
   return geometry && geometry.type == 'Polygon' ? getFieldsWithGeoRss(interpolatedFields, geojsonFeature) : interpolatedFields;
 }
 
+function hasGeoRssTemplateString(interpolatedFields) {
+  return /{{(.*?)}}/.test(_.get(interpolatedFields, 'item.georss:where', ''))
+}
 
 function getFieldsWithGeoRss(rssItem: Record<string, any>, feature: Feature): Record<string, any> {
   const extent = geojsonExtent(feature.geometry);

--- a/src/rss/compile-rss-feed.ts.test.ts
+++ b/src/rss/compile-rss-feed.ts.test.ts
@@ -100,4 +100,59 @@ describe('generating RSS 2 feed', () => {
    
   });
 
+  it('should use interpolated template georss if RSS template contains georss', async function () {
+    const rssItemTemplate = {
+      item: {
+        title: '{{name}}',
+        description: '{{searchDescription}}',
+        author: '{{orgContactEmail}}',
+        category: '{{categories}}',
+        'georss:where': '{{boundary:toGeoRss}}'
+      }
+    };
+
+    const templateTransforms = {
+      toGeoRss: (_key, _val) => {
+        return {
+          'gml:Envelope': {
+            'gml:lowerCorner': '1 2',
+            'gml:upperCorner': '3 4'
+          }
+        };
+      }
+    };
+
+    const itemRss = compileRssFeedEntry(datasetFromApi, rssItemTemplate, templateTransforms);
+    const { item } = jsonFromXml(itemRss);
+    expect(item['georss:where']).toBeDefined();
+    expect(item['georss:where']).toStrictEqual({
+      'gml:Envelope': {
+        'gml:lowerCorner': '1 2',
+        'gml:upperCorner': '3 4'
+      }
+    })
+  });
+
+  it('should remove georss key if interpolated georss is undefined', async function () {
+    const rssItemTemplate = {
+      item: {
+        title: '{{name}}',
+        description: '{{searchDescription}}',
+        author: '{{orgContactEmail}}',
+        category: '{{categories}}',
+        'georss:where': '{{boundary:toGeoRss}}'
+      }
+    };
+
+    const templateTransforms = {
+      toGeoRss: (_key, _val) => {
+        return undefined;
+      }
+    };
+
+    const itemRss = compileRssFeedEntry(datasetFromApi, rssItemTemplate, templateTransforms);
+    const { item } = jsonFromXml(itemRss);
+    expect(item['georss:where']).toBeUndefined();
+  });
+
 });


### PR DESCRIPTION
This PR allows `geoRSS` to be added directly via RSS feed templates if available else it will generated geoRSS from geoJSON from provider.

Related PR: https://github.com/ArcGIS/hub-feeds-api/pull/41

https://devtopia.esri.com/dc/hub/issues/11748